### PR TITLE
Add project on enhancing base sample for uneq. prob. sampling

### DIFF
--- a/projects/enhance-sample/index.Rmd
+++ b/projects/enhance-sample/index.Rmd
@@ -1,0 +1,119 @@
+---
+title: Enhancing `sample.int` for unequal probability sampling
+description: "" # Optional short description for post on Discussions thread
+author: Ahmadou Dicko
+output: html_document
+categories: [C, R, Wishlist, Models]
+comments:
+  giscus:
+    repo: "r-devel/r-project-sprint-2023"
+    repo-id: "R_kgDOIhAibA"
+    category: "Proposals"
+    category-id: "DIC_kwDOIhAibM4CW3GY"
+    mapping: "title"
+    reactions-enabled: true
+    loading: lazy
+bibliography: ref.bib
+---
+
+## Problem statement
+
+The method of unequal probability sampling without replacement, as implemented in `base::sample` (`base::sample.int`), relies on a sequential algorithm (coded in `C`). This algorithm does not respect the prescribed inclusion probabilities (as defined by the `prob` parameter). Consequently, it can produce a biased Horvitz-Thompson estimate.
+
+The issue can affect other packages as illustrated by this [dplyr issue affecting slice_sample](https://github.com/tidyverse/dplyr/issues/6848).
+
+To better understand the problem, consider the illustration below, following [@tille2023remarks].
+
+```{r}
+set.seed(123)
+N <- 12
+n <- 4
+p <- (1:N)/sum(1:N)
+pik <- n * p
+pikest_base <- vector(mode = "numeric", length = N)
+nsim <- 1e4
+for (j in 1:nsim) {
+  s <- sample.int(n = N, size = n, replace = FALSE, prob = p)
+  pikest_base[s] <- pikest_base[s] + 1
+}
+pikest_base <- pikest_base/nsim
+```
+
+After estimating the inclusion probabilities with `sample.int`, we can compare them with algorithms from the `sampling` package, as highlighted in its documentation.
+
+```{r}
+library(sampling)
+set.seed(42)
+pikest_maxent <- sapply(1:nsim, \(i) UPmaxentropy(pik))
+pikest_maxent <- rowMeans(pikest_maxent)
+
+pikest_pivot <- sapply(1:nsim, \(i) UPpivotal(pik))
+pikest_pivot <- rowMeans(pikest_pivot)
+
+cbind(pik,
+      pikest_base,
+      pikest_maxent,
+      pikest_pivot)
+```
+
+To evaluate the accuracy of the sampling algorithm, we can compute the following test statistic:
+
+
+$$
+z_k = \dfrac{(\hat{\pi_k} - \pi_k) \sqrt{M}}{\sqrt{\pi_k (1 - \pi_k)}}
+$$
+
+where $M$ is the number of simulations.
+
+$z_k$ should be asymptotically normal under the null hypothesis that the sampling algorithm is correct. The implementation is as follows:
+
+```{r}
+test_stat <- function(est, pik)
+  (est - pik) / sqrt(pik * (1 - pik)/nsim)
+```
+
+We can compute this test statistics for each method and check its normality using a `qqplot`.
+
+```{r, echo = FALSE}
+par(mfrow = c(2, 2))
+set.seed(3)
+theo <- rnorm(n = N)
+qqnorm(theo, main = "Normal distribution (benchmark)")
+qqline(theo)
+qqnorm(test_stat(pikest_base, pik), main = "base::sample")
+qqline(theo)
+qqnorm(test_stat(pikest_maxent, pik), main = "sampling::UPmaxentropy")
+qqline(theo)
+qqnorm(test_stat(pikest_pivot, pik), main = "sampling::UPpivot")
+qqline(theo)
+```
+
+These charts show how `base::sample` deviates more from normality compared to the other two competing algorithms available in the `sampling` package.
+
+
+## Proposed solution
+
+- **Option 1:**
+  - Refine the documentation for `base::sample` and `base::sample.int`.
+  - Suggest adding a concise paragraph in the `Details` section, explaining why the function is not suitable for unequal probability sampling based on inclusion probabilities.
+
+- **Option 2:**
+  - Introduce a new `C` function and an additional argument to `sample.int` to incorporate the new method.
+  - Retain the original [`ProbSampleNoReplace` `C` function](https://github.com/wch/r-source/blob/7ad1c5790841572c88955b1da805d28174ff0b56/src/main/random.c#L406).
+  - By default, `base::sample.int` should utilize `ProbSampleNoReplace` for unequal probability sampling without replacement. This ensures backward compatibility and prevents disruptions to existing code.
+
+
+It is hard to pick one algorithm over the multitude of available unequal probability sampling algorithms. In theory, there's no best algorithm for unequal probability. However, the Maximum Entropy Sampling algorithm (`sampling::UPmaxentropy`) also known as Conditional Poisson Sampling is an algorithm with good properties (maximizing entropy) that can be used as a reference.
+
+## Project requirements
+
+- Good understanding of survey sampling algorithms.
+- Good C and R coding skills.
+
+## Project outcomes
+
+An enhanced version of `sample` (`sample.int`) with a new argument to select the new algorithm for unequal probability sampling.
+
+## References
+
+<div id="refs"></div>

--- a/projects/enhance-sample/ref.bib
+++ b/projects/enhance-sample/ref.bib
@@ -1,0 +1,10 @@
+@article{tille2023remarks,
+  title={Remarks on some misconceptions about unequal probability sampling without replacement},
+  author={Till{\'e}, Yves},
+  journal={Computer Science Review},
+  volume={47},
+  pages={100533},
+  year={2023},
+  publisher={Elsevier},
+  doi={10.1016/j.cosrev.2022.100533}
+}


### PR DESCRIPTION
Adding the project to work on `base::sample.int` and make it more friendly for survey statisticians who want to use it for unequal probability sampling.